### PR TITLE
Feat: Simplify pom by using variables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,8 @@
         <kotlin.version>1.7.22</kotlin.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <minecraft.version>1.19.3</minecraft.version>
+        <minecraft.revision>R0.1-SNAPSHOT</minecraft.revision> <!-- It's probably not going to change much -->
     </properties>
     <url>daniel-maile.com</url>
 
@@ -118,9 +120,9 @@
                         </goals>
                         <id>remap-obf</id>
                         <configuration>
-                            <srgIn>org.spigotmc:minecraft-server:1.19.3-R0.1-SNAPSHOT:txt:maps-mojang</srgIn>
+                            <srgIn>org.spigotmc:minecraft-server:${minecraft.version}-${minecraft.revision}:txt:maps-mojang</srgIn>
                             <reverse>true</reverse>
-                            <remappedDependencies>org.spigotmc:spigot:1.19.3-R0.1-SNAPSHOT:jar:remapped-mojang
+                            <remappedDependencies>org.spigotmc:spigot:${minecraft.version}-${minecraft.revision}:jar:remapped-mojang
                             </remappedDependencies>
                             <remappedArtifactAttached>true</remappedArtifactAttached>
                             <remappedClassifierName>remapped-obf</remappedClassifierName>
@@ -135,8 +137,8 @@
                             <inputFile>
                                 ${project.build.directory}/${project.artifactId}-${project.version}-remapped-obf.jar
                             </inputFile>
-                            <srgIn>org.spigotmc:minecraft-server:1.19.3-R0.1-SNAPSHOT:csrg:maps-spigot</srgIn>
-                            <remappedDependencies>org.spigotmc:spigot:1.19.3-R0.1-SNAPSHOT:jar:remapped-obf
+                            <srgIn>org.spigotmc:minecraft-server:${minecraft.version}-${minecraft.revision}:csrg:maps-spigot</srgIn>
+                            <remappedDependencies>org.spigotmc:spigot:${minecraft.version}-${minecraft.revision}:jar:remapped-obf
                             </remappedDependencies>
                         </configuration>
                     </execution>
@@ -182,13 +184,13 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.19.3-R0.1-SNAPSHOT</version>
+            <version>${minecraft.version}-${minecraft.revision}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
-            <version>1.19.3-R0.1-SNAPSHOT</version>
+            <version>${minecraft.version}-${minecraft.revision}</version>
             <classifier>remapped-mojang</classifier>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
I added two variables minecraft.version and minecraft.revision
`minecraft.revision` is R0.1-SNAPSHOT and it hardly ever changes
`minecraft.version` is 1.19.3 and it's the only thing that will need to be changed when there's an update (e.g. 1.19.4) So you won't ever need to touch all the Paper and NMS remapping.