### PR TITLE
Perf: Reduced jar size by excluding unneeded dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,21 @@
             <artifactId>triumph-gui</artifactId>
             <version>3.1.4</version>
             <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.kyori</groupId>
+                    <artifactId>adventure-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.kyori</groupId>
+                    <artifactId>adventure-text-serializer-legacy</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.kyori</groupId>
+                    <artifactId>adventure-text-serializer-gson</artifactId>
+                </exclusion>
+
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>


### PR DESCRIPTION
TriumphGUI was importing some dependencies to make it compatible with spigot api, however, this plugin is meant to be used with paper, which already includes those dependencies, so they don't need to be compiled